### PR TITLE
Prevent NullPointerException for value instances

### DIFF
--- a/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
@@ -155,6 +155,9 @@ public class StructNode extends ChunkNode {
   private ChunkNode create(Method getter) throws ReflectiveOperationException {
     final Object field = getter.invoke(value);
     final String name  = getter.getName();
+    if (field == null || !attrStart.containsKey(name) || !attrEnd.containsKey(name)) {
+        return new SimpleNode(name, null, this, 0, 0, 0);
+    }
     final int s = attrStart.get(name);
     final int e = attrEnd.get(name);
     if (List.class.isAssignableFrom(getter.getReturnType())) {

--- a/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
@@ -154,9 +154,12 @@ public class StructNode extends ChunkNode {
    */
   private ChunkNode create(Method getter) throws ReflectiveOperationException {
     final Object field = getter.invoke(value);
-    final String name  = getter.getName();
-    if (field == null || !attrStart.containsKey(name) || !attrEnd.containsKey(name)) {
+    if (field == null) {
         return new SimpleNode(name, null, this, 0, 0, 0);
+    }
+    final String name = getter.getName();
+    if (!attrStart.containsKey(name) || !attrEnd.containsKey(name)) {
+        return new SimpleNode(name, field, this, 0, 0, 0);
     }
     final int s = attrStart.get(name);
     final int e = attrEnd.get(name);

--- a/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
@@ -154,15 +154,9 @@ public class StructNode extends ChunkNode {
    */
   private ChunkNode create(Method getter) throws ReflectiveOperationException {
     final Object field = getter.invoke(value);
-    if (field == null) {
-        return new SimpleNode(name, null, this, 0, 0, 0);
-    }
     final String name = getter.getName();
-    if (!attrStart.containsKey(name) || !attrEnd.containsKey(name)) {
-        return new SimpleNode(name, field, this, 0, 0, 0);
-    }
-    final int s = attrStart.get(name);
-    final int e = attrEnd.get(name);
+    final int s = attrStart.getOrDefault(name, -1);
+    final int e = attrEnd.getOrDefault(name, -1);
     if (List.class.isAssignableFrom(getter.getReturnType())) {
       final List<Integer> sa = arrStart.get(name);
       final List<Integer> se = arrEnd.get(name);


### PR DESCRIPTION
Previous behavior:
The sample files bmp.ksy and grad8rgb.bmp from ide.kaitai.io would cause a NullPointerException when expanding the `dibInfo` field. The exception happened because [value instances](https://doc.kaitai.io/user_guide.html#_value_instances) do not get added to the attrStart and attrEnd maps.

New behavior:
No exception. The size is shown as zero.
![image](https://user-images.githubusercontent.com/9056906/171541982-60df52b7-895c-4208-9f5c-27009b0829ab.png)

