### PR TITLE
Keep reference to type of SimpleNode value

### DIFF
--- a/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
@@ -77,9 +77,9 @@ public abstract class ChunkNode extends ValueNode {
    * @throws ReflectiveOperationException If {@code value} is {@link KaitaiStruct}
    *         and it was compiled without debug info (which includes position information)
    */
-  protected ChunkNode create(String name, Object value, long offset, long start, long end) throws ReflectiveOperationException {
+  protected ChunkNode create(String name, Object value, Class<?> classOfValue, long offset, long start, long end) throws ReflectiveOperationException {
     return value instanceof KaitaiStruct
       ? new StructNode(name, (KaitaiStruct)value, this, offset, start, end)
-      : new SimpleNode(name, value, this, offset, start, end);
+      : new SimpleNode(name, value, classOfValue, this, offset, start, end);
   }
 }

--- a/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
@@ -23,11 +23,14 @@
  */
 package ru.mingun.kaitai.struct.tree;
 
+import javax.swing.tree.TreeNode;
 import java.util.ArrayList;
-import static java.util.Collections.enumeration;
 import java.util.Enumeration;
 import java.util.List;
-import javax.swing.tree.TreeNode;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.enumeration;
 
 /**
  * Node, that represents a repeated data in struct definition. An each repeated value
@@ -91,7 +94,21 @@ public class ListNode extends ChunkNode {
         try {
           final int s = arrStart.get(index);
           final int e = arrEnd.get(index);
-          children.add(create("[" + index + ']', obj, 0, s, e));
+
+          /*
+           We cannot access the generic type of the List at runtime due to
+           type erasure. Instead, look for a non-null element in the List,
+           which will tell us the type of the whole list.
+           */
+          final Class<?> valueClass;
+          final Optional<?> nonNullElement = value.stream().filter(Objects::nonNull).findAny();
+          if (nonNullElement.isPresent()) {
+            valueClass = nonNullElement.get().getClass();
+          } else {
+            valueClass = null;
+          }
+
+          children.add(create("[" + index + ']', obj, valueClass, 0, s, e));
           ++index;
         } catch (ReflectiveOperationException ex) {
           throw new UnsupportedOperationException("Can't get list value at index " + index, ex);

--- a/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
@@ -37,13 +37,19 @@ public class SimpleNode extends ChunkNode {
   /** Parsed value of non-constructed type. */
   private final Object value;
 
-  SimpleNode(String name, Object value, ChunkNode parent, long offset, long start, long end) {
+  /** Replace value.getClass() when value==null. */
+  private final Class<?> classOfValue;
+
+  SimpleNode(String name, Object value, Class<?> valueClass, ChunkNode parent, long offset, long start, long end) {
     super(name, parent, offset, start, end);
     this.value = value;
+    this.classOfValue = valueClass;
   }
 
   @Override
   public Object getValue() { return value; }
+
+  public Class<?> getClassOfValue() { return classOfValue; }
 
   //<editor-fold defaultstate="collapsed" desc="TreeNode">
   @Override

--- a/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
@@ -162,7 +162,7 @@ public class StructNode extends ChunkNode {
       final List<Integer> se = arrEnd.get(name);
       return new ListNode(name, (List<?>)field, this, offset, s, e, sa, se);
     }
-    return create(name, field, start, s, e);
+    return create(name, field, getter.getReturnType(), start, s, e);
   }
 
   private ArrayList<ChunkNode> init() {


### PR DESCRIPTION
This is for my idea to add different colored icons for different data types, mentioned in issue #8. 

The `value` field in SimpleNode.java is an `Object`, so when it is `null` we cannot tell what type it is. This PR adds field `Class classOfValue`.

KSY to easily get a null value:
```yaml
meta:
  id: null_enum_test
seq:
  - id: null_enum
    enum: my_enum
enums:
   my_enum:
    1: one
```

Screenshot:
![image](https://user-images.githubusercontent.com/9056906/171961544-84607485-0a4a-40e0-923f-42b187094261.png)

The code in ListNode.java is kind of gross. We can't check the generic type of an ArrayList at runtime because of [type erasure](https://docs.oracle.com/javase/tutorial/java/generics/erasure.html). So, I look for a non-null element in the List and check its type.