### PR TITLE
Fix NPE for "value" instances and optional fields

### DIFF
--- a/src/main/java/ru/mingun/kaitai/struct/Span.java
+++ b/src/main/java/ru/mingun/kaitai/struct/Span.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2020-2022 Mingun.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package ru.mingun.kaitai.struct;
+
+/**
+ *
+ * @author Mingun
+ */
+public class Span {
+  /** Position in a parsed stream where value begins. */
+  private final long start;
+  /** Position in a parsed stream where value ends (exclusive). */
+  private final long end;
+
+  /**
+   * Creates a span that tree node occupies in a stream.
+   *
+   * @param start Byte offset from the begin of a root stream, where that object starts
+   * @param end Byte offset from the begin of a root stream, where that object ends (exclusive)
+   */
+  public Span(long start, long end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  /** Position in a root stream where value begins. */
+  public long getStart() { return start; }
+  /** Position in a root stream where value ends (exclusive). */
+  public long getEnd() { return end; }
+  /**
+   * Returns occupied size in bytes in the stream.
+   *
+   * @return Size of this node in bytes
+   */
+  public long size() { return end - start; }
+}

--- a/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
@@ -42,7 +42,10 @@ public abstract class ChunkNode extends ValueNode {
     this.span = span;
   }
 
-  /** Space that this node occupies in a stream. */
+  /**
+   * Space that this node occupies in a stream or {@code null} for missing
+   * optional fields and calculated values ("value" instances).
+   */
   public Span getSpan() { return span; }
 
   /**

--- a/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ChunkNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2020-2021 Mingun.
+ * Copyright 2020-2022 Mingun.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@ package ru.mingun.kaitai.struct.tree;
 
 import io.kaitai.struct.KaitaiStruct;
 import javax.swing.tree.TreeNode;
+import ru.mingun.kaitai.struct.Span;
 
 /**
  * Base node for all nodes in the tree, that represents parts of message in
@@ -33,53 +34,32 @@ import javax.swing.tree.TreeNode;
  * @author Mingun
  */
 public abstract class ChunkNode extends ValueNode {
-  /** Start offset of parent node in root stream (i.e. global offset). */
-  protected final long offset;
-  /** Position in parsed stream where this node begins. */
-  protected final long start;
-  /** Position in parsed stream where this node ends (exclusive). */
-  protected final long end;
+  /** Space that this node occupies in a stream. */
+  protected final Span span;
 
-  ChunkNode(String name, TreeNode parent, long offset, long start, long end) {
+  ChunkNode(String name, TreeNode parent, Span span) {
     super(name, parent);
-    this.offset = offset;
-    this.start = start;
-    this.end = end;
+    this.span = span;
   }
 
-  /** Position in root stream where parent of this node begins. */
-  public long getParentStart() { return offset; }
-  /** Position in root stream where this node begins. */
-  public long getStart() { return offset + start; }
-  /** Position position in root stream where this node ends (exclusive). */
-  public long getEnd() { return offset + end; }
-  /** Local position in parsed stream where this node begins. */
-  public long getLocalStart() { return start; }
-  /** Local position in parsed stream where this node ends (exclusive). */
-  public long getLocalEnd() { return end; }
-  /**
-   * Returns occupied size in bytes in the stream.
-   *
-   * @return Size of this node in bytes
-   */
-  public long size() { return end - start; }
+  /** Space that this node occupies in a stream. */
+  public Span getSpan() { return span; }
 
   /**
    * Creates tree node for object.
    *
    * @param name Name of field, under which this field arrives
    * @param value Value of object
-   * @param offset Byte offset from begin of root stream of parent node
-   * @param start Byte offset from begin of stream, where that object starts
-   * @param end Byte offset from begin of stream, where that object ends (exclusive)
+   * @param span Space that node is occupied in a stream
+   *
    * @return
    *
    * @throws ReflectiveOperationException If {@code value} is {@link KaitaiStruct}
    *         and it was compiled without debug info (which includes position information)
    */
-  protected ChunkNode create(String name, Object value, long offset, long start, long end) throws ReflectiveOperationException {
+  protected ChunkNode create(String name, Object value, Span span) throws ReflectiveOperationException {
     return value instanceof KaitaiStruct
-      ? new StructNode(name, (KaitaiStruct)value, this, offset, start, end)
-      : new SimpleNode(name, value, this, offset, start, end);
+      ? new StructNode(name, (KaitaiStruct)value, this, span)
+      : new SimpleNode(name, value, this, span);
   }
 }

--- a/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
@@ -28,6 +28,7 @@ import static java.util.Collections.enumeration;
 import java.util.Enumeration;
 import java.util.List;
 import javax.swing.tree.TreeNode;
+import ru.mingun.kaitai.struct.Span;
 
 /**
  * Node, that represents a repeated data in struct definition. An each repeated value
@@ -45,11 +46,11 @@ public class ListNode extends ChunkNode {
   private final List<Integer> arrEnd;
 
   ListNode(String name, List<?> value, StructNode parent,
-    long offset, long start, long end,
+    Span span,
     List<Integer> arrStart,
     List<Integer> arrEnd
   ) {
-    super(name, parent, offset, start, end);
+    super(name, parent, span);
     this.value = value;
     this.arrStart = arrStart;
     this.arrEnd   = arrEnd;
@@ -80,7 +81,7 @@ public class ListNode extends ChunkNode {
 
   @Override
   public String toString() {
-    return name + " [count = " + value.size() + "; offset = " + getStart() + "; size = " + size() + "]";
+    return name + " [count = " + value.size() + "; offset = " + span.getStart() + "; size = " + span.size() + "]";
   }
 
   private List<ChunkNode> init() {
@@ -91,7 +92,8 @@ public class ListNode extends ChunkNode {
         try {
           final int s = arrStart.get(index);
           final int e = arrEnd.get(index);
-          children.add(create("[" + index + ']', obj, 0, s, e));
+          final Span span = new Span(s, e);
+          children.add(create("[" + index + ']', obj, span));
           ++index;
         } catch (ReflectiveOperationException ex) {
           throw new UnsupportedOperationException("Can't get list value at index " + index, ex);

--- a/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/ListNode.java
@@ -81,7 +81,13 @@ public class ListNode extends ChunkNode {
 
   @Override
   public String toString() {
-    return name + " [count = " + value.size() + "; offset = " + span.getStart() + "; size = " + span.size() + "]";
+    final StringBuilder sb = new StringBuilder(name);
+    sb.append(" [count = ").append(value.size());
+    if (span != null) {
+      sb.append("; offset = ").append(span.getStart())
+        .append("; size = ").append(span.size());
+    }
+    return sb.append(']').toString();
   }
 
   private List<ChunkNode> init() {

--- a/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2020-2021 Mingun.
+ * Copyright 2020-2022 Mingun.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ package ru.mingun.kaitai.struct.tree;
 import static java.util.Collections.emptyEnumeration;
 import java.util.Enumeration;
 import javax.swing.tree.TreeNode;
+import ru.mingun.kaitai.struct.Span;
 
 /**
  * Node, that represents any simple object (such as {@code byte[]}, {@link Integer}
@@ -37,8 +38,8 @@ public class SimpleNode extends ChunkNode {
   /** Parsed value of non-constructed type. */
   private final Object value;
 
-  SimpleNode(String name, Object value, ChunkNode parent, long offset, long start, long end) {
-    super(name, parent, offset, start, end);
+  SimpleNode(String name, Object value, ChunkNode parent, Span span) {
+    super(name, parent, span);
     this.value = value;
   }
 
@@ -70,7 +71,9 @@ public class SimpleNode extends ChunkNode {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder(name);
-    toString(sb.append(" [offset = ").append(getStart()).append("; size = ").append(size()).append("] = "), value);
+    toString(sb.append(" [offset = ").append(span.getStart())
+               .append("; size = ").append(span.size())
+               .append("] = "), value);
     return sb.toString();
   }
 }

--- a/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/SimpleNode.java
@@ -71,9 +71,12 @@ public class SimpleNode extends ChunkNode {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder(name);
-    toString(sb.append(" [offset = ").append(span.getStart())
-               .append("; size = ").append(span.size())
-               .append("] = "), value);
+    if (span != null) {
+      sb.append(" [offset = ").append(span.getStart())
+        .append("; size = ").append(span.size())
+        .append(']');
+    }
+    toString(sb.append(" = "), value);
     return sb.toString();
   }
 }

--- a/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
+++ b/src/main/java/ru/mingun/kaitai/struct/tree/StructNode.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License
  *
- * Copyright 2020-2021 Mingun.
+ * Copyright 2020-2022 Mingun.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.TreeNode;
+import ru.mingun.kaitai.struct.Span;
 
 /**
  * Node, that represents single {@link KaitaiStruct} object. Each struct field
@@ -65,10 +66,10 @@ public class StructNode extends ChunkNode {
    *         debug info (which includes position information)
    */
   public StructNode(String name, KaitaiStruct value, TreeNode parent) throws ReflectiveOperationException {
-    this(name, value, parent, 0, 0, value._io().pos());
+    this(name, value, parent, new Span(0, value._io().pos()));
   }
-  StructNode(String name, KaitaiStruct value, TreeNode parent, long offset, long start, long end) throws ReflectiveOperationException {
-    super(name, parent, offset, start, end);
+  StructNode(String name, KaitaiStruct value, TreeNode parent, Span span) throws ReflectiveOperationException {
+    super(name, parent, span);
     final Class<?> clazz = value.getClass();
     // getDeclaredMethods() doesn't guaranties any particular order, so sort fields
     // according order in the type
@@ -138,8 +139,8 @@ public class StructNode extends ChunkNode {
   public String toString() {
     return name + " [" + value.getClass().getSimpleName()
       + "; fields = " + fields.size()
-      + "; offset = " + getStart()
-      + "; size = " + size()
+      + "; offset = " + span.getStart()
+      + "; size = " + span.size()
       + "]";
   }
 
@@ -157,12 +158,13 @@ public class StructNode extends ChunkNode {
     final String name  = getter.getName();
     final int s = attrStart.get(name);
     final int e = attrEnd.get(name);
+    final Span span = new Span(s, e);
     if (List.class.isAssignableFrom(getter.getReturnType())) {
       final List<Integer> sa = arrStart.get(name);
       final List<Integer> se = arrEnd.get(name);
-      return new ListNode(name, (List<?>)field, this, offset, s, e, sa, se);
+      return new ListNode(name, (List<?>)field, this, span, sa, se);
     }
-    return create(name, field, start, s, e);
+    return create(name, field, span);
   }
 
   private ArrayList<ChunkNode> init() {


### PR DESCRIPTION
Move all offsets to a dedicates `Span` class and remove `offset`, that should be represent offset of substream in a parent stream. This generally does not work, because Kaitai Struct has ability to set any IO stream for an instance. The proper fix should be on the generator and runtime size -- https://github.com/kaitai-io/kaitai_struct_java_runtime/issues/26.

Introduce a `getSpan()` method for a node, which could return `null` in case of
- if node represents an optional and missed sequential field
- if node represents an optional and missed "parse" instance
- if node represents a "value" instance

@pfroud, FYI
